### PR TITLE
Add Python GUI for Word placeholder replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ FakesAssemblies/
 # Icon must ends with two \r.
 Icon
 
+__pycache__/
 # Thumbnails
 ._*
 

--- a/docx_placeholder_gui/README.md
+++ b/docx_placeholder_gui/README.md
@@ -1,0 +1,20 @@
+# Word Placeholder GUI
+
+This folder contains a simple Python application to replace placeholders inside a `.docx` file via a graphical user interface. The user can load a Word document, specify a placeholder and its replacement text, and save the modified document.
+
+## Requirements
+
+- Python 3
+- `python-docx` for editing `.docx` files
+
+Install dependencies using `pip install python-docx`.
+
+## Usage
+
+Run the script:
+
+```bash
+python word_gui.py
+```
+
+A window will open allowing you to select a document, enter a placeholder and replacement text, perform the replacement, and save the result.

--- a/docx_placeholder_gui/word_gui.py
+++ b/docx_placeholder_gui/word_gui.py
@@ -1,0 +1,83 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from docx import Document
+
+
+class WordEditor:
+    """Simple GUI application to replace placeholders in a Word document."""
+
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        master.title("Word Placeholder Replacer")
+        self.doc = None
+
+        self.open_button = tk.Button(master, text="Open Document", command=self.open_file)
+        self.open_button.pack(pady=5)
+
+        self.placeholder_label = tk.Label(master, text="Placeholder:")
+        self.placeholder_label.pack()
+        self.placeholder_entry = tk.Entry(master, width=40)
+        self.placeholder_entry.pack()
+
+        self.replacement_label = tk.Label(master, text="Replacement:")
+        self.replacement_label.pack()
+        self.replacement_entry = tk.Entry(master, width=40)
+        self.replacement_entry.pack()
+
+        self.replace_button = tk.Button(master, text="Replace", command=self.replace_text)
+        self.replace_button.pack(pady=5)
+
+        self.save_button = tk.Button(master, text="Save As", command=self.save_file)
+        self.save_button.pack()
+
+    def open_file(self) -> None:
+        """Load a .docx file."""
+        file_path = filedialog.askopenfilename(filetypes=[("Word documents", "*.docx")])
+        if file_path:
+            self.doc = Document(file_path)
+            messagebox.showinfo("Loaded", f"Loaded document: {file_path}")
+
+    def replace_text(self) -> None:
+        """Replace placeholder text in the loaded document."""
+        if not self.doc:
+            messagebox.showwarning("No document", "Please open a document first.")
+            return
+        placeholder = self.placeholder_entry.get()
+        replacement = self.replacement_entry.get()
+        if not placeholder:
+            messagebox.showwarning("No placeholder", "Please enter a placeholder.")
+            return
+
+        for paragraph in self.doc.paragraphs:
+            for run in paragraph.runs:
+                run.text = run.text.replace(placeholder, replacement)
+
+        for table in self.doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    for paragraph in cell.paragraphs:
+                        for run in paragraph.runs:
+                            run.text = run.text.replace(placeholder, replacement)
+
+        messagebox.showinfo("Replaced", "Replacement complete.")
+
+    def save_file(self) -> None:
+        """Save the modified document."""
+        if not self.doc:
+            messagebox.showwarning("No document", "Please open a document first.")
+            return
+        save_path = filedialog.asksaveasfilename(defaultextension=".docx",
+                                                filetypes=[("Word documents", "*.docx")])
+        if save_path:
+            self.doc.save(save_path)
+            messagebox.showinfo("Saved", f"Document saved as: {save_path}")
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = WordEditor(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `word_gui.py` Python script using Tkinter and python-docx
- add README with usage instructions
- ignore Python bytecode in `.gitignore`

## Testing
- `python3 -m py_compile docx_placeholder_gui/word_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684b995dbc3c832aa0477887815436a0